### PR TITLE
add prep_nisar & rm setuptools_scm

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install .[cli] -vv
   entry_points:
     - mintpy = mintpy.__main__:main
@@ -47,6 +47,7 @@ build:
     - prep_gmtsar.py = mintpy.cli.prep_gmtsar:main
     - prep_hyp3.py = mintpy.cli.prep_hyp3:main
     - prep_isce.py = mintpy.cli.prep_isce:main
+    - prep_nisar.py = mintpy.cli.prep_nisar:main
     - prep_roipac.py = mintpy.cli.prep_roipac:main
     - prep_snap.py = mintpy.cli.prep_snap:main
     - reference_date.py = mintpy.cli.reference_date:main
@@ -107,7 +108,6 @@ requirements:
     - rich
     - scikit-image
     - scipy
-    - setuptools-scm
     - shapely
     - utm
 


### PR DESCRIPTION
+ add `prep_nisar` in the `entry_points` section, to be consistent with the code repo.
+ rm `setuptools_scm` from `requirements/run` as the issue has been resolved on the `pysolid` side, which is now available on conda-forge.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
